### PR TITLE
Patch github.py

### DIFF
--- a/services/github.py
+++ b/services/github.py
@@ -5,7 +5,7 @@ class Github(object):
 
     def __init__(self, options):
         self.repo_owner = options["repo_owner"]
-        self.repo_name = options["repo_owner"]
+        self.repo_name = options["repo_name"]
         self.access_token = options["access_token"]
 
     def request(self, path):


### PR DESCRIPTION
Fixes assignment of `repo_owner` config value to `repo_name` variable in github service initializer.
Closes #2 